### PR TITLE
Fix php 8.4 deprecation notices

### DIFF
--- a/src/ServerRequestCreator.php
+++ b/src/ServerRequestCreator.php
@@ -13,7 +13,7 @@ final class ServerRequestCreator
      * @param ServerNormalizerInterface|null $normalizer
      * @return ServerRequestInterface
      */
-    public static function create(ServerNormalizerInterface $normalizer = null): ServerRequestInterface
+    public static function create(?ServerNormalizerInterface $normalizer = null): ServerRequestInterface
     {
         return self::createFromGlobals(null, null, null, null, null, $normalizer);
     }
@@ -28,12 +28,12 @@ final class ServerRequestCreator
      * @return ServerRequestInterface
      */
     public static function createFromGlobals(
-        array $server = null,
-        array $files = null,
-        array $cookie = null,
-        array $get = null,
-        array $post = null,
-        ServerNormalizerInterface $normalizer = null
+        ?array $server = null,
+        ?array $files = null,
+        ?array $cookie = null,
+        ?array $get = null,
+        ?array $post = null,
+        ?ServerNormalizerInterface $normalizer = null
     ): ServerRequestInterface {
         $server ??= $_SERVER;
         $normalizer ??= new SapiNormalizer();

--- a/src/UploadedFileCreator.php
+++ b/src/UploadedFileCreator.php
@@ -28,8 +28,8 @@ final class UploadedFileCreator
         $streamOrFile,
         int $size,
         int $error,
-        string $clientFilename = null,
-        string $clientMediaType = null
+        ?string $clientFilename = null,
+        ?string $clientMediaType = null
     ): UploadedFileInterface {
         return new UploadedFile($streamOrFile, $size, $error, $clientFilename, $clientMediaType);
     }


### PR DESCRIPTION
```txt
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Breaks BC?    | no
| Fixed issues  | In php 8.4, implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead
```